### PR TITLE
Add C# native port mapper

### DIFF
--- a/Config.cs
+++ b/Config.cs
@@ -16,6 +16,7 @@ public class Config : ModConfig
     [CustomModConfigItem(typeof(Input))] public string CustomIPv6Address;
     [DefaultValue("40800")] [CustomModConfigItem(typeof(Input))] public string CustomMappedRemotePort;
     [DefaultValue("26000")] [CustomModConfigItem(typeof(Input))] public string CustomMappedLocalPort;
+    [DefaultValue(true)] public bool UseTinyPortMapper;
     [CustomModConfigItem(typeof(IPv6Test1))] public object IPv6Test1;
     [CustomModConfigItem(typeof(IPv6Test2))] public object IPv6Test2;
     [CustomModConfigItem(typeof(IPv6Test3))] public object IPv6Test3;

--- a/Localization/en-US_Mods.IPv6Mapper.hjson
+++ b/Localization/en-US_Mods.IPv6Mapper.hjson
@@ -74,5 +74,10 @@ Configs: {
 			Label: Google Search: "How to enable IPv6"
 			Tooltip: ""
 		}
+
+		UseTinyPortMapper: {
+			Label: Use Tiny Port Mapper
+			Tooltip: ""
+		}
 	}
 }

--- a/Localization/zh-Hans_Mods.IPv6Mapper.hjson
+++ b/Localization/zh-Hans_Mods.IPv6Mapper.hjson
@@ -74,5 +74,10 @@ Configs: {
 			Label: IPv6开启教程
 			Tooltip: ""
 		}
+
+		UseTinyPortMapper: {
+			// Label: Use Tiny Port Mapper
+			// Tooltip: ""
+		}
 	}
 }

--- a/PortMapper.cs
+++ b/PortMapper.cs
@@ -1,0 +1,103 @@
+using System.Net;
+using System.Net.Sockets;
+using System.Threading;
+
+namespace IPv6Mapper;
+
+public class PortMapper
+{
+    private Socket tcpListener;
+    private IPEndPoint srcEndPoint;
+    private IPEndPoint dstEndPoint;
+
+    private class SocketPair
+    {
+        public Socket srcSocket { get; private set; }
+        public Socket dstSocket { get; private set; }
+        public byte[] buffer { get; private set; }
+
+        public SocketPair(Socket source, Socket destination) {
+            srcSocket = source;
+            dstSocket = destination;
+            buffer = new byte[8192];
+        }
+
+        public void Close() {
+            srcSocket.Close();
+            dstSocket.Close();
+        }
+    }
+
+    public static IPAddress Family2IP(AddressFamily family) {
+        return family == AddressFamily.InterNetworkV6 ? IPAddress.IPv6Any : IPAddress.Any;
+    }
+
+    public static AddressFamily TheOtherFamily(AddressFamily family) {
+        return family == AddressFamily.InterNetworkV6 ? AddressFamily.InterNetwork :
+                                                        AddressFamily.InterNetworkV6;
+    }
+
+    public PortMapper(AddressFamily srcFamily, int srcPort, IPAddress dstAddr, int dstPort) {
+        tcpListener = new Socket(srcFamily, SocketType.Stream, ProtocolType.Tcp);
+        srcEndPoint = new IPEndPoint(Family2IP(srcFamily), srcPort);
+        dstEndPoint = new IPEndPoint(dstAddr, dstPort);
+    }
+
+    /**
+     * Start the main port forwarding loop in a thread
+     */
+    public Thread Start() {
+        Thread thread = new(Run);
+        thread.Start();
+        return thread;
+    }
+
+    public void Stop() {
+        tcpListener.Close();
+    }
+
+    /**
+     * Wait for incoming connections on source port
+     */
+    public void Run() {
+        tcpListener.Bind(srcEndPoint);
+        tcpListener.Listen();
+
+        while (true) {
+            try {
+                Socket peer = tcpListener.Accept();
+                Socket relay = new(TheOtherFamily(peer.AddressFamily),
+                    SocketType.Stream, ProtocolType.Tcp);
+                SocketPair reqPair = new(peer, relay);
+                SocketPair rspPair = new(relay, peer);
+                Thread reqThread, rspThread;
+                relay.Connect(dstEndPoint);
+                // Connection extablished. Now start worker threads to
+                // forward data in both directions.
+                reqThread = new Thread(() => {DataForward(reqPair);});
+                rspThread = new Thread(() => {DataForward(rspPair);});
+                reqThread.Start();
+                rspThread.Start();
+            } catch {
+                tcpListener.Close();
+                break;
+            }
+        }
+    }
+
+    /**
+     * Receive data from one socket and send to the other
+     */
+    private static void DataForward(SocketPair pair) {
+        try {
+            while (true) {
+                int bytesRead = pair.srcSocket.Receive(pair.buffer, SocketFlags.None);
+                if (bytesRead > 0) {
+                    pair.dstSocket.Send(pair.buffer, bytesRead, SocketFlags.None);
+                }
+            }
+        } catch {
+            pair.Close();
+        }
+    }
+}


### PR DESCRIPTION
This commit implements a C# native port mapper, which can hopefully:
1. Eliminate the need to ship tinyportmapper binaries together with this mod.
2. Support Mac and Linux. In other words, this mod *should* work on all platforms supported by tModLoader.

This commit also includes a config option that allows users to select whether to use tinyportmapper or the C# native one. Currently the default is tinyportmapper. On non-Windows platforms this config has no effect and the C# one is always used.

Please note that this commit has only been tested on Windows (between two tModLoader instances running in the host and a VM).
